### PR TITLE
Update repository name

### DIFF
--- a/.github/aws/README.md
+++ b/.github/aws/README.md
@@ -9,4 +9,4 @@ This needs to be done once in the AWS console (because no access keys have permi
 - [create stack](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create)
 - file: `github-role.yml`
 - stack name: github-oidc-provider
-- `FullRepoName` parameter: `mnapoli/tideways-daemon-ami`
+- `FullRepoName` parameter: `tideways/tideways-daemon-ami`


### PR DESCRIPTION
Before tagging a release, I realized we need to update the permissions used by GitHub Actions for deploying into the AWS account.

Instead of API keys (which can leak), we are using GitHub OIDC to authenticate into the AWS account. The way this works is that a "stack" is deployed into the AWS account and it creates a role that allows this repository (via its name).

Since the repository name changed, you will need to update the role by updating the stack in CloudFormation.

I am not 100% sure if you will need to re-upload the YAML template, or if you'll be able to change the parameter and redeploy straightaway. In the extreme case where it's confusing, you can delete the stack and re-create it following the instructions listed in the README.md that I just edited.

I can help if you have any trouble.